### PR TITLE
Remove 'Radium' mod entry from useful_mods.json

### DIFF
--- a/scripts/useful_mods.json
+++ b/scripts/useful_mods.json
@@ -278,26 +278,6 @@
             ]
         },
         {
-            "display_name": "Radium*",
-            "link": {
-                "curseforge": "https://www.curseforge.com/minecraft/mc-mods/radium-reforged",
-                "modrinth": "https://modrinth.com/mod/radium"
-            },
-            "description": "Radium is an Unofficial Fork of CaffeineMC's 'Lithium'",
-            "alternatives": "[Lithium](https://www.curseforge.com/minecraft/mc-mods/lithium) on relevant versions",
-            "categories": [
-                "performance"
-            ],
-            "versions": [
-                "1.20.1",
-                "1.21.1"
-            ],
-            "loaders": [
-                "forge",
-                "neoforge"
-            ]
-        },
-        {
             "display_name": "Quick Pack",
             "link": {
                 "curseforge": "https://www.curseforge.com/minecraft/mc-mods/quick-pack",


### PR DESCRIPTION
Listing radium is unnecessary as it wasn't updated for two years and is superseded by lithium which is available for all versions covered by radium

### Contributor License Agreement
[Full CLA](https://github.com/Modpack-Dev-Knowledgebase/modpack-dev-wiki/blob/main/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X] I have read and agreed to the CLA for Modpack Dev Knowledgebase which states that I have the legal right to submit this contribution under an open source license, and that I consent to the repository owners having legal rights over this contribution while retaining ownership myself.
