### PR TITLE
Remove Radium from useful mods for 1.21.1

### DIFF
--- a/scripts/useful_mods.json
+++ b/scripts/useful_mods.json
@@ -289,8 +289,7 @@
                 "performance"
             ],
             "versions": [
-                "1.20.1",
-                "1.21.1"
+                "1.20.1"
             ],
             "loaders": [
                 "forge",


### PR DESCRIPTION
Radium for 1.21.1 is superseded by lithium which is over two years of updates ahead. There is no need to list it in useful mods for neoforge 1.21.1

EDIT: I went a little overzealous with this. Radium seems to still be relevant for 1.20.1 forge, but not for 1.21.1 and should not be listed under useful mods for neoforge 1.21.1

### Contributor License Agreement
[Full CLA](https://github.com/Modpack-Dev-Knowledgebase/modpack-dev-wiki/blob/main/CLA.md)
*Contributors: Please "X" in the following box to acknowledge our CLA*
- [X ] I have read and agreed to the CLA for Modpack Dev Knowledgebase which states that I have the legal right to submit this contribution under an open source license, and that I consent to the repository owners having legal rights over this contribution while retaining ownership myself.
